### PR TITLE
Fixed screenshot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Pre-requisites
 Screenshots
 -------------
 
-<img src="screenshots/screenshot-1.png" height="400" alt="Screenshot"/> 
+<img src="screenshots/screenshot1.png" height="400" alt="Screenshot"/>
 
 Getting Started
 ---------------


### PR DESCRIPTION
The image are collapsed by wrong screenshot file name.

<img width="206" alt="googlesamples_android-appshortcuts" src="https://cloud.githubusercontent.com/assets/1269214/19542131/d07861d0-96a6-11e6-91a9-e0e6b8a99796.png">

So I fixed the image file name.
