### PR TITLE
fixed shortcut target class 

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -23,7 +23,7 @@
         <intent
             android:action="com.example.android.appshortcuts.ADD_WEBSITE"
             android:targetPackage="com.example.android.appshortcuts"
-            android:targetClass="com.example.android.appshortcuts.Main"
+            android:targetClass="com.example.android.shortcutsample.Main"
             />
     </shortcut>
 </shortcuts>


### PR DESCRIPTION
this fixes #2  as we might all know that this was a mistake to have different package name than the `applicationId` i chose not to fix that but actually keep it that way as a proof example that you can have the `applicationId` and the `manifest` `package` different and yet shortcuts will work. i just ran into this while implementing the shortcuts `API` into my app.
