### PR TITLE
Fix for Could not  find com.android.tools.build:gradle:3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
Fix for #31 
Adding Google's new maven repo as suggested here -> https://stackoverflow.com/questions/44071080/could-not-find-com-android-tools-buildgradle3-0-0-alpha1-in-circle-ci