### PR TITLE
Add intent-filter with deep-links and targetPackage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.gradle
+build
+
+.idea
+*.iml
+
+local.properties

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Pre-requisites
 --------------
 
 - Android SDK 27
-- Android Build Tools v27.0.2
+- Android Build Tools v27.0.3
 - Android Support Repository
 
 Screenshots

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "27.0.3"
 
     defaultConfig {
-        applicationId "com.example.android.shortcutsample"
+        applicationId "com.example.android.appshortcuts"
         minSdkVersion 25
         targetSdkVersion 27
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.example.android.shortcutsample"
         minSdkVersion 25
-        targetSdkVersion 25
-        jackOptions {
-            enabled true
-        }
+        targetSdkVersion 27
     }
 
     compileOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,8 +17,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.appshortcuts">
 
-    <uses-sdk android:minSdkVersion="25" />
-
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="app"
+                    android:host="custom"
+                    android:path="/deep-link" />
+            </intent-filter>
             <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>
         </activity>
         <receiver android:name="com.example.android.appshortcuts.MyReceiver">

--- a/app/src/main/java/com/example/android/appshortcuts/Main.java
+++ b/app/src/main/java/com/example/android/appshortcuts/Main.java
@@ -41,7 +41,7 @@ public class Main extends ListActivity implements OnClickListener {
     private static final String ID_ADD_WEBSITE = "add_website";
 
     private static final String ACTION_ADD_WEBSITE =
-            "com.example.android.shortcutsample.ADD_WEBSITE";
+            "com.example.android.appshortcuts.ADD_WEBSITE";
 
     private MyAdapter mAdapter;
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -17,6 +17,7 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name">アプリのショートカットサンプル</string>
     <string name="add_new_website">ウェブサイト追加</string>
+    <string name="add_new_website_deeplink">ウェブサイト追加（ディープリンク）</string>
     <string name="add_new_website_short">追加</string>
     <string name="existing_shortcuts">既存のショートカット:</string>
     <string name="remove_shortcut">削除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name">App Shortcuts Sample</string>
     <string name="add_new_website">Add New Website</string>
+    <string name="add_new_website_deeplink">Add New Website (deeplink)</string>
     <string name="add_new_website_short">Add Website</string>
     <string name="existing_shortcuts">Existing shortcuts:</string>
     <string name="remove_shortcut">Remove</string>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -26,4 +26,14 @@
             android:targetClass="com.example.android.appshortcuts.Main"
             />
     </shortcut>
+    <shortcut
+        android:shortcutId="add_website_deeplink"
+        android:icon="@drawable/add"
+        android:shortcutShortLabel="@string/add_new_website_deeplink"
+        android:shortcutLongLabel="@string/add_new_website_deeplink">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:data="app://custom/deep-link"
+            android:targetPackage="this.package.does.not.exists" />
+    </shortcut>
 </shortcuts>

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
## Description
- Add an intent-filter using deep-links;
- Add strings in both english and japanese;
- Add a static shortcut using both the deep-link and the targetPackage to show that the targetPackage is not taken into account (this is a **bug** in production API: https://issuetracker.google.com/issues/135863691)

This PR must be merged after https://github.com/googlesamples/android-AppShortcuts/pull/34